### PR TITLE
fix: PSR-15 handle() signature violations and TranslationManager typo

### DIFF
--- a/src/Auth/Middleware/AuthorizationMiddleware.php
+++ b/src/Auth/Middleware/AuthorizationMiddleware.php
@@ -22,7 +22,7 @@ class AuthorizationMiddleware implements MiddlewareInterface
 	{
 		$routeResult = $request->getAttribute(RouteResult::class, false);
 		if (! $routeResult) {
-			return $handler->handle($request, $handler);
+			return $handler->handle($request);
 		}
 
 		$route = $routeResult->getMatchedRoute();
@@ -32,6 +32,6 @@ class AuthorizationMiddleware implements MiddlewareInterface
 			return $middleware->loggedCheck($request, $handler);
 		}
 
-		return $handler->handle($request, $handler);
+		return $handler->handle($request);
 	}
 }

--- a/src/Maintenance/Middleware/MaintenanceMiddleware.php
+++ b/src/Maintenance/Middleware/MaintenanceMiddleware.php
@@ -25,7 +25,7 @@ class MaintenanceMiddleware implements MiddlewareInterface
 	{
 		if ($this->app->isMaintenanceMode()) {
 			if ($this->isIpAllowed($request)) {
-				return $handler->handle($request, $handler);
+				return $handler->handle($request);
 			}
 
 			$appCfg = $this->app->config;
@@ -48,7 +48,7 @@ class MaintenanceMiddleware implements MiddlewareInterface
 			return $result;
 		}
 
-		return $handler->handle($request, $handler);
+		return $handler->handle($request);
 	}
 
 	private function isIpAllowed(ServerRequestInterface $request): bool

--- a/src/Middleware/ActionInjectionMiddleware.php
+++ b/src/Middleware/ActionInjectionMiddleware.php
@@ -31,7 +31,7 @@ class ActionInjectionMiddleware implements MiddlewareInterface
 		$routeResult = $request->getAttribute(RouteResult::class, false);
 
 		if (! $routeResult) {
-			return $handler->handle($request, $handler);
+			return $handler->handle($request);
 		}
 
 		$middleware = $routeResult->getMatchedRoute()->getMiddleware();
@@ -58,6 +58,6 @@ class ActionInjectionMiddleware implements MiddlewareInterface
 			$routeResult->set(Action::class, $action);
 		}
 
-		return $handler->handle($request, $handler);
+		return $handler->handle($request);
 	}
 }

--- a/src/Middleware/NotFoundMiddleware.php
+++ b/src/Middleware/NotFoundMiddleware.php
@@ -26,11 +26,11 @@ class NotFoundMiddleware implements MiddlewareInterface
 	public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
 	{
 		try {
-			$response = $handler->handle($request, $handler);
+			$response = $handler->handle($request);
 
 			return $response;
 		} catch (EmptyPipelineException $e) {
-			return $this->notFoundHandler->handle($request, $handler);
+			return $this->notFoundHandler->handle($request);
 		}
 	}
 }

--- a/src/Middleware/ValidationMiddleware.php
+++ b/src/Middleware/ValidationMiddleware.php
@@ -23,7 +23,7 @@ class ValidationMiddleware implements MiddlewareInterface
 		$routeResult = $request->getAttribute(RouteResult::class, false);
 
 		if (! $routeResult) {
-			return $handler->handle($request, $handler);
+			return $handler->handle($request);
 		}
 
 		$route = $routeResult->getMatchedRoute();
@@ -33,6 +33,6 @@ class ValidationMiddleware implements MiddlewareInterface
 			return $middleware->validate($request, $handler);
 		}
 
-		return $handler->handle($request, $handler);
+		return $handler->handle($request);
 	}
 }

--- a/src/Router/ActionMiddlewareDecorator.php
+++ b/src/Router/ActionMiddlewareDecorator.php
@@ -123,7 +123,7 @@ class ActionMiddlewareDecorator implements MiddlewareInterface
 			$valid = $this->executor->execute([$page, $validateMethod], $args);
 
 			if ($valid) {
-				return $handler->handle($request, $handler);
+				return $handler->handle($request);
 			}
 			// if it's not validated, we need to handle the error response
 			$handleErrorMethod = "handleError";
@@ -135,7 +135,7 @@ class ActionMiddlewareDecorator implements MiddlewareInterface
 			return $this->buildView($page, $this->method, $response, $request, $handler);
 		}
 
-		return $handler->handle($request, $handler);
+		return $handler->handle($request);
 	}
 
 	public function loggedCheck(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -157,7 +157,7 @@ class ActionMiddlewareDecorator implements MiddlewareInterface
 			//return new RedirectResponse($this->router->gen("login"));
 		}
 
-		return $handler->handle($request, $handler);
+		return $handler->handle($request);
 	}
 
 	public function checkPermissions(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -191,6 +191,6 @@ class ActionMiddlewareDecorator implements MiddlewareInterface
 			}
 		}
 
-		return $handler->handle($request, $handler);
+		return $handler->handle($request);
 	}
 }

--- a/src/Translation/TranslationManager.php
+++ b/src/Translation/TranslationManager.php
@@ -488,7 +488,7 @@ class TranslationManager implements TranslationManagerInterface
 		try {
 			$domainExtra = '';
 
-			return $this->getTranslators($domain, $domainExtra, $type);
+			return $this->getTranslator($domain, $domainExtra, $type);
 		} catch (InvalidArgumentException $e) {
 			return null;
 		}


### PR DESCRIPTION
## Summary

Fixes all PSR-15 `RequestHandlerInterface::handle()` signature violations and a typo in `TranslationManager`.

## Changes

### PSR-15 Fix (14 occurrences across 6 files)

`handle($request, $handler)` → `handle($request)`

`RequestHandlerInterface::handle()` only accepts 1 argument per PSR-15 spec. The extra `$handler` argument was silently ignored by PHP but violates the interface contract.

**Affected files:**
- `src/Router/ActionMiddlewareDecorator.php` (4 occurrences)
- `src/Middleware/ActionInjectionMiddleware.php` (2)
- `src/Middleware/NotFoundMiddleware.php` (2)
- `src/Middleware/ValidationMiddleware.php` (2)
- `src/Auth/Middleware/AuthorizationMiddleware.php` (2)
- `src/Maintenance/Middleware/MaintenanceMiddleware.php` (2)

### TranslationManager Typo Fix

`getDomainTranslator()` was calling `$this->getTranslators()` (plural) but the method is named `getTranslator()` (singular). This would cause a fatal error at runtime.

**File:** `src/Translation/TranslationManager.php` (line 491)